### PR TITLE
Go/missing typing

### DIFF
--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import types
 from enum import Enum
-from typing import Any, KeysView, Type, TypeVar, cast
+from typing import Any, KeysView, Type, TypeVar, Union, cast
 
 import mongoengine
 import pymongo
@@ -96,6 +96,11 @@ class Post(Document):
     )
 
     font = fields.EnumField(Font)
+    font_required = fields.EnumField(Font, required=True)
+    font_default = fields.EnumField(Font, default=Font.Helvetica)
+    font_required_default = fields.EnumField(
+        Font, required=True, default=Font.Helvetica
+    )
 
     def set_hidden(self, hidden: bool) -> None:
         self.hidden = hidden
@@ -153,6 +158,21 @@ def main() -> None:
     first_post.tags.values()
     first_post.errors
     first_post.results
+    first_post.font
+
+    def log_optional_font(f: Union[Font, None]) -> None:
+        print(f)
+
+    log_optional_font(first_post.font)
+
+    def log_required_font(f: Font) -> None:
+        print(f)
+
+    log_required_font(first_post.font_required)
+    first_post.font_required_default = None
+
+    log_required_font(first_post.font_default)
+    first_post.font_default = None
 
     p = Post()
     p.validate()

--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import types
+from enum import Enum
 from typing import Any, KeysView, Type, TypeVar, cast
 
 import mongoengine
@@ -50,6 +51,12 @@ class Recipe(Document):
     description = fields.StringField()
 
 
+class Font(Enum):
+    Helvetica = ("Helvetica",)
+    Arial = ("Arial",)
+    Times = "Times New Roman"
+
+
 class Post(Document):
     meta = {
         "collection": "posts",
@@ -87,6 +94,8 @@ class Post(Document):
         field=fields.StringField(required=True),
         help_text=("Map tag names to descriptions"),
     )
+
+    font = fields.EnumField(Font)
 
     def set_hidden(self, hidden: bool) -> None:
         self.hidden = hidden

--- a/typings/mongoengine/__init__.pyi
+++ b/typings/mongoengine/__init__.pyi
@@ -6,10 +6,10 @@ from mongoengine.document import Document, DynamicDocument, EmbeddedDocument
 from mongoengine.errors import DoesNotExist, NotUniqueError, ValidationError
 from mongoengine.queryset.queryset import QuerySet
 from mongoengine.queryset.visitor import Q
-from pymongo import MongoClient
+from pymongo import MongoClient, ReadPreference
 
 def connect(name: str, alias: str = ..., host: Optional[str] = ...) -> MongoClient: ...
-def register_connection(host: str, alias: str) -> None: ...
+def register_connection(alias: str, db: str = None, name: str = None, host: str = None, port: int = None, read_preference: ReadPreference = ReadPreference.Primary, username: str = None, password: str = None, authentication_source: str = None, authentication_mechanism: str = None, **kwargs) -> None: ...
 
 __all__ = [
     "Q",

--- a/typings/mongoengine/__init__.pyi
+++ b/typings/mongoengine/__init__.pyi
@@ -11,16 +11,15 @@ from pymongo import MongoClient, ReadPreference
 def connect(name: str, alias: str = ..., host: Optional[str] = ...) -> MongoClient: ...
 def register_connection(
     alias: str,
-    db: str = None,
-    name: str = None,
-    host: str = None,
-    port: int = None,
-    read_preference: ReadPreference = ReadPreference.Primary,
-    username: str = None,
-    password: str = None,
-    authentication_source: str = None,
-    authentication_mechanism: str = None,
-    **kwargs
+    db: Optional[str] = ...,
+    name: Optional[str] = ...,
+    host: Optional[str] = ...,
+    port: Optional[int] = ...,
+    read_preference: ReadPreference = ...,
+    username: Optional[str] = ...,
+    password: Optional[str] = ...,
+    authentication_source: Optional[str] = ...,
+    authentication_mechanism: Optional[str] = ...,
 ) -> None: ...
 
 __all__ = [

--- a/typings/mongoengine/__init__.pyi
+++ b/typings/mongoengine/__init__.pyi
@@ -9,7 +9,19 @@ from mongoengine.queryset.visitor import Q
 from pymongo import MongoClient, ReadPreference
 
 def connect(name: str, alias: str = ..., host: Optional[str] = ...) -> MongoClient: ...
-def register_connection(alias: str, db: str = None, name: str = None, host: str = None, port: int = None, read_preference: ReadPreference = ReadPreference.Primary, username: str = None, password: str = None, authentication_source: str = None, authentication_mechanism: str = None, **kwargs) -> None: ...
+def register_connection(
+    alias: str,
+    db: str = None,
+    name: str = None,
+    host: str = None,
+    port: int = None,
+    read_preference: ReadPreference = ReadPreference.Primary,
+    username: str = None,
+    password: str = None,
+    authentication_source: str = None,
+    authentication_mechanism: str = None,
+    **kwargs
+) -> None: ...
 
 __all__ = [
     "Q",

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -17,6 +17,7 @@ from typing import (
     overload,
 )
 from uuid import UUID
+from enum import Enum
 
 from bson import ObjectId
 from mongoengine.base import BaseField, ComplexBaseField
@@ -1068,3 +1069,88 @@ class ReferenceField(BaseField):
         blank: bool = ...,
     ) -> None: ...
     def __getitem__(self, arg: Any) -> Any: ...
+
+
+class EnumField(Generic[_ST, _GT], BaseField):
+    @overload
+    def __init__(
+        self: EnumField[Optional[UUID], Optional[Enum]],
+        enum: Optional[Enum],
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[False] = ...,
+        default: None = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[Enum]] = ...,
+        null: Literal[False] = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: EnumField[Optional[Enum], Enum],
+        enum: Optional[Enum],
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[False] = ...,
+        default: Union[Enum, Callable[[], Enum]] = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[Enum]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: EnumField[Enum, Enum],
+        enum: Optional[Enum],
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[True] = ...,
+        default: None = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[Enum]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: EnumField[Optional[Enum], Enum],
+        enum: Optional[Enum],
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[True] = ...,
+        default: Union[Enum, Callable[[], Enum]] = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[Enum]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: EnumField[Enum, Enum],
+        enum: Optional[Enum],
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: bool = ...,
+        default: Union[Enum, None, Callable[[], Enum]] = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[True] = ...,
+        choices: Optional[Iterable[Enum]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> None: ...
+    def __set__(self, instance: Any, value: _ST) -> None: ...
+    def __get__(self, instance: Any, owner: Any) -> _GT: ...

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -1073,8 +1073,8 @@ class ReferenceField(BaseField):
 class EnumField(Generic[_ST, _GT], BaseField):
     @overload
     def __init__(
-        self: EnumField[Optional[Enum], Optional[Enum]],
-        enum: Optional[Enum],
+        self: EnumField[Optional[Type[Enum]], Optional[Type[Enum]]],
+        enum: Optional[Type[Enum]],
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -1082,7 +1082,7 @@ class EnumField(Generic[_ST, _GT], BaseField):
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Enum]] = ...,
+        choices: Optional[Iterable[Type[Enum]]] = ...,
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -1070,11 +1070,14 @@ class ReferenceField(BaseField):
     ) -> None: ...
     def __getitem__(self, arg: Any) -> Any: ...
 
+_T_ENUM = TypeVar("_T_ENUM", bound=Enum)
+
 class EnumField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: EnumField[Optional[Type[Enum]], Optional[Type[Enum]]],
-        enum: Optional[Type[Enum]],
+    def __new__(
+        cls,
+        enum: Type[_T_ENUM],
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -1082,74 +1085,61 @@ class EnumField(Generic[_ST, _GT], BaseField):
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Type[Enum]]] = ...,
-        null: Literal[False] = ...,
-        verbose_name: Optional[str] = ...,
-        help_text: Optional[str] = ...,
-    ) -> None: ...
-    @overload
-    def __init__(
-        self: EnumField[Optional[Type[Enum]], Type[Enum]],
-        enum: Optional[Type[Enum]],
-        db_field: str = ...,
-        name: Optional[str] = ...,
-        required: Literal[False] = ...,
-        default: Union[Type[Enum], Callable[[], Type[Enum]]] = ...,
-        unique: bool = ...,
-        unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Type[Enum]]] = ...,
+        choices: Optional[Iterable[_T_ENUM]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EnumField[Optional[_T_ENUM], Optional[_T_ENUM]]: ...
     @overload
-    def __init__(
-        self: EnumField[Type[Enum], Type[Enum]],
-        enum: Optional[Type[Enum]],
+    def __new__(
+        cls,
+        enum: Type[_T_ENUM],
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[False] = ...,
+        default: Union[_T_ENUM, Callable[[], _T_ENUM]],
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[_T_ENUM]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> EnumField[Optional[_T_ENUM], _T_ENUM]: ...
+    @overload
+    def __new__(
+        cls,
+        enum: Type[_T_ENUM],
+        *,
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Type[Enum]]] = ...,
+        choices: Optional[Iterable[_T_ENUM]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EnumField[_T_ENUM, _T_ENUM]: ...
     @overload
-    def __init__(
-        self: EnumField[Optional[Type[Enum]], Type[Enum]],
-        enum: Optional[Type[Enum]],
+    def __new__(
+        cls,
+        enum: Type[_T_ENUM],
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[Type[Enum], Callable[[], Type[Enum]]] = ...,
+        required: Literal[True],
+        default: Union[_T_ENUM, Callable[[], _T_ENUM]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Type[Enum]]] = ...,
+        choices: Optional[Iterable[_T_ENUM]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
-    @overload
-    def __init__(
-        self: EnumField[Type[Enum], Type[Enum]],
-        enum: Optional[Type[Enum]],
-        db_field: str = ...,
-        name: Optional[str] = ...,
-        required: bool = ...,
-        default: Union[Type[Enum], None, Callable[[], Type[Enum]]] = ...,
-        unique: bool = ...,
-        unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
-        choices: Optional[Iterable[Type[Enum]]] = ...,
-        null: bool = ...,
-        verbose_name: Optional[str] = ...,
-        help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EnumField[Optional[_T_ENUM], _T_ENUM]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -1073,7 +1073,7 @@ class ReferenceField(BaseField):
 class EnumField(Generic[_ST, _GT], BaseField):
     @overload
     def __init__(
-        self: EnumField[Optional[UUID], Optional[Enum]],
+        self: EnumField[Optional[Enum], Optional[Enum]],
         enum: Optional[Enum],
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -1089,24 +1089,24 @@ class EnumField(Generic[_ST, _GT], BaseField):
     ) -> None: ...
     @overload
     def __init__(
-        self: EnumField[Optional[Enum], Enum],
-        enum: Optional[Enum],
+        self: EnumField[Optional[Type[Enum]], Type[Enum]],
+        enum: Optional[Type[Enum]],
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[Enum, Callable[[], Enum]] = ...,
+        default: Union[Type[Enum], Callable[[], Type[Enum]]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Enum]] = ...,
+        choices: Optional[Iterable[Type[Enum]]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> None: ...
     @overload
     def __init__(
-        self: EnumField[Enum, Enum],
-        enum: Optional[Enum],
+        self: EnumField[Type[Enum], Type[Enum]],
+        enum: Optional[Type[Enum]],
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -1114,39 +1114,39 @@ class EnumField(Generic[_ST, _GT], BaseField):
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Enum]] = ...,
+        choices: Optional[Iterable[Type[Enum]]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> None: ...
     @overload
     def __init__(
-        self: EnumField[Optional[Enum], Enum],
-        enum: Optional[Enum],
+        self: EnumField[Optional[Type[Enum]], Type[Enum]],
+        enum: Optional[Type[Enum]],
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
-        default: Union[Enum, Callable[[], Enum]] = ...,
+        default: Union[Type[Enum], Callable[[], Type[Enum]]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
-        choices: Optional[Iterable[Enum]] = ...,
+        choices: Optional[Iterable[Type[Enum]]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> None: ...
     @overload
     def __init__(
-        self: EnumField[Enum, Enum],
-        enum: Optional[Enum],
+        self: EnumField[Type[Enum], Type[Enum]],
+        enum: Optional[Type[Enum]],
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
-        default: Union[Enum, None, Callable[[], Enum]] = ...,
+        default: Union[Type[Enum], None, Callable[[], Type[Enum]]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[True] = ...,
-        choices: Optional[Iterable[Enum]] = ...,
+        choices: Optional[Iterable[Type[Enum]]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum
 from typing import (
     Any,
     Callable,
@@ -17,7 +18,6 @@ from typing import (
     overload,
 )
 from uuid import UUID
-from enum import Enum
 
 from bson import ObjectId
 from mongoengine.base import BaseField, ComplexBaseField
@@ -1069,7 +1069,6 @@ class ReferenceField(BaseField):
         blank: bool = ...,
     ) -> None: ...
     def __getitem__(self, arg: Any) -> Any: ...
-
 
 class EnumField(Generic[_ST, _GT], BaseField):
     @overload


### PR DESCRIPTION
Add missing typing for `register_connection` and `EnumField` according to [API](http://docs.mongoengine.org/apireference.html#mongoengine.register_connection) for `register_connection` and [the source](https://sourcegraph.com/github.com/MongoEngine/mongoengine/-/blob/mongoengine/fields.py#L1610) for `EnumField`