### PR TITLE
ref(mongoengine/fields): overload __new__ for pyright

### DIFF
--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -26,7 +26,7 @@ cast(Any, QuerySet).__class_getitem__ = types.MethodType(no_op, QuerySet)
 
 class PostAttachment(EmbeddedDocument):
     url = fields.StringField()
-    name = fields.StringField()
+    name = fields.StringField(max_length=10)
 
 
 class PostQuerySet(QuerySet["Post"]):

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -32,28 +32,32 @@ _ST = TypeVar("_ST")
 _GT = TypeVar("_GT")
 
 class ObjectIdField(Generic[_ST, _GT], BaseField):
+    # ObjectIdField()
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: bool = ...,
+        primary_key: Literal[False] = ...,
         choices: Optional[Iterable[ObjectId]] = ...,
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> ObjectIdField[Optional[ObjectId], Optional[ObjectId]]: ...
+    # ObjectIdField(default=ObjectId)
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[ObjectId, Callable[[], ObjectId]] = ...,
+        default: Union[ObjectId, Callable[[], ObjectId]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -62,12 +66,14 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> ObjectIdField[Optional[ObjectId], ObjectId]: ...
+    # ObjectIdField(required=True)
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -77,13 +83,15 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> ObjectIdField[ObjectId, ObjectId]: ...
+    # ObjectIdField(required=True, default=ObjectId)
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[ObjectId, Callable[[], ObjectId]] = ...,
+        required: Literal[True],
+        default: Union[ObjectId, Callable[[], ObjectId]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -92,16 +100,18 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> ObjectIdField[Optional[ObjectId], ObjectId]: ...
+    # ObjectIdField(primiary_key=True)
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
         default: Union[ObjectId, None, Callable[[], ObjectId]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[ObjectId]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -218,6 +228,7 @@ class EmailField(StringField[_ST, _GT]):
     @overload
     def __new__(
         cls,
+        *,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -239,6 +250,7 @@ class EmailField(StringField[_ST, _GT]):
     @overload
     def __new__(
         cls,
+        *,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -248,7 +260,7 @@ class EmailField(StringField[_ST, _GT]):
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[str, Callable[[], str]] = ...,
+        default: Union[str, Callable[[], str]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -260,6 +272,7 @@ class EmailField(StringField[_ST, _GT]):
     @overload
     def __new__(
         cls,
+        *,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -268,7 +281,7 @@ class EmailField(StringField[_ST, _GT]):
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -281,6 +294,7 @@ class EmailField(StringField[_ST, _GT]):
     @overload
     def __new__(
         cls,
+        *,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -289,8 +303,8 @@ class EmailField(StringField[_ST, _GT]):
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[str, Callable[[], str]] = ...,
+        required: Literal[True],
+        default: Union[str, Callable[[], str]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -302,6 +316,7 @@ class EmailField(StringField[_ST, _GT]):
     @overload
     def __new__(
         cls,
+        *,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -314,7 +329,7 @@ class EmailField(StringField[_ST, _GT]):
         default: Union[str, Callable[[], str], None] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[str]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -327,6 +342,7 @@ class IntField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -344,12 +360,13 @@ class IntField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[int, Callable[[], int]] = ...,
+        default: Union[int, Callable[[], int]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -361,11 +378,12 @@ class IntField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -378,12 +396,13 @@ class IntField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[int, Callable[[], int]] = ...,
+        required: Literal[True],
+        default: Union[int, Callable[[], int]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -395,6 +414,7 @@ class IntField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -403,7 +423,7 @@ class IntField(Generic[_ST, _GT], BaseField):
         default: Union[int, Callable[[], int], None] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[int]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -416,6 +436,7 @@ class FloatField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -433,12 +454,13 @@ class FloatField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[float, Callable[[], float]] = ...,
+        default: Union[float, Callable[[], float]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -450,11 +472,12 @@ class FloatField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -467,12 +490,13 @@ class FloatField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[float, Callable[[], float]] = ...,
+        required: Literal[True],
+        default: Union[float, Callable[[], float]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -484,6 +508,7 @@ class FloatField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -492,7 +517,7 @@ class FloatField(Generic[_ST, _GT], BaseField):
         default: Union[float, Callable[[], float], None] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[float]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -505,6 +530,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -525,6 +551,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -533,7 +560,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[Decimal, Callable[[], Decimal]] = ...,
+        default: Union[Decimal, Callable[[], Decimal]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -545,6 +572,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -552,7 +580,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         rounding: str = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -565,6 +593,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -572,8 +601,8 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         rounding: str = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[Decimal, Callable[[], Decimal]] = ...,
+        required: Literal[True],
+        default: Union[Decimal, Callable[[], Decimal]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -585,6 +614,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -596,7 +626,7 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         default: Union[Decimal, Callable[[], Decimal], None] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[Decimal]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -609,13 +639,14 @@ class BooleanField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: bool = ...,
+        primary_key: Literal[False] = ...,
         choices: Optional[Iterable[bool]] = ...,
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
@@ -624,10 +655,11 @@ class BooleanField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[bool, Callable[[], bool]] = ...,
+        default: Union[bool, Callable[[], bool]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -639,9 +671,10 @@ class BooleanField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -654,10 +687,11 @@ class BooleanField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[bool, Callable[[], bool]] = ...,
+        required: Literal[True],
+        default: Union[bool, Callable[[], bool]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -669,13 +703,14 @@ class BooleanField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
         default: Union[bool, None, Callable[[], bool]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[bool]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -688,6 +723,7 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -703,10 +739,11 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[datetime, Callable[[], datetime]] = ...,
+        default: Union[datetime, Callable[[], datetime]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -718,9 +755,10 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -733,10 +771,11 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[datetime, Callable[[], datetime]] = ...,
+        required: Literal[True],
+        default: Union[datetime, Callable[[], datetime]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -748,13 +787,14 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
         default: Union[datetime, None, Callable[[], datetime]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[datetime]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
@@ -1078,6 +1118,7 @@ class UUIDField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -1094,11 +1135,12 @@ class UUIDField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[UUID, Callable[[], UUID]] = ...,
+        default: Union[UUID, Callable[[], UUID]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -1110,10 +1152,11 @@ class UUIDField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -1126,11 +1169,12 @@ class UUIDField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[UUID, Callable[[], UUID]] = ...,
+        required: Literal[True],
+        default: Union[UUID, Callable[[], UUID]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -1142,6 +1186,7 @@ class UUIDField(Generic[_ST, _GT], BaseField):
     @overload
     def __new__(
         cls,
+        *,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -1149,7 +1194,7 @@ class UUIDField(Generic[_ST, _GT], BaseField):
         default: Union[UUID, None, Callable[[], UUID]] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[UUID]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -31,8 +31,8 @@ _GT = TypeVar("_GT")
 
 class ObjectIdField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: ObjectIdField[Optional[ObjectId], Optional[ObjectId]],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -44,10 +44,10 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> ObjectIdField[Optional[ObjectId], Optional[ObjectId]]: ...
     @overload
-    def __init__(
-        self: ObjectIdField[Optional[ObjectId], ObjectId],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -59,10 +59,10 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> ObjectIdField[Optional[ObjectId], ObjectId]: ...
     @overload
-    def __init__(
-        self: ObjectIdField[ObjectId, ObjectId],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -74,10 +74,10 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> ObjectIdField[ObjectId, ObjectId]: ...
     @overload
-    def __init__(
-        self: ObjectIdField[Optional[ObjectId], ObjectId],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -89,10 +89,10 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> ObjectIdField[Optional[ObjectId], ObjectId]: ...
     @overload
-    def __init__(
-        self: ObjectIdField[ObjectId, ObjectId],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
@@ -104,14 +104,14 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> ObjectIdField[ObjectId, ObjectId]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class StringField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: StringField[Optional[str], Optional[str]],
+    def __new__(
+        cls,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -126,10 +126,10 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[Optional[str], Optional[str]]: ...
     @overload
-    def __init__(
-        self: StringField[Optional[str], str],
+    def __new__(
+        cls,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -144,10 +144,10 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[Optional[str], str]: ...
     @overload
-    def __init__(
-        self: StringField[str, str],
+    def __new__(
+        cls,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -162,10 +162,10 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[str, str]: ...
     @overload
-    def __init__(
-        self: StringField[Optional[str], str],
+    def __new__(
+        cls,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -180,10 +180,10 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[Optional[str], str]: ...
     @overload
-    def __init__(
-        self: StringField[str, str],
+    def __new__(
+        cls,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -198,14 +198,14 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[str, str]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class EmailField(StringField[_ST, _GT]):
     @overload
-    def __init__(
-        self: EmailField[Optional[str], Optional[str]],
+    def __new__(
+        cls,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -223,10 +223,10 @@ class EmailField(StringField[_ST, _GT]):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EmailField[Optional[str], Optional[str]]: ...
     @overload
-    def __init__(
-        self: EmailField[Optional[str], str],
+    def __new__(
+        cls,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -244,10 +244,10 @@ class EmailField(StringField[_ST, _GT]):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EmailField[Optional[str], str]: ...
     @overload
-    def __init__(
-        self: EmailField[str, str],
+    def __new__(
+        cls,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -265,10 +265,10 @@ class EmailField(StringField[_ST, _GT]):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EmailField[str, str]: ...
     @overload
-    def __init__(
-        self: EmailField[Optional[str], str],
+    def __new__(
+        cls,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -286,10 +286,10 @@ class EmailField(StringField[_ST, _GT]):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EmailField[Optional[str], str]: ...
     @overload
-    def __init__(
-        self: EmailField[str, str],
+    def __new__(
+        cls,
         domain_whitelist: Optional[List[str]] = ...,
         allow_utf8_user: bool = ...,
         allow_ip_domain: bool = ...,
@@ -307,14 +307,14 @@ class EmailField(StringField[_ST, _GT]):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> EmailField[str, str]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class IntField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: IntField[Optional[int], Optional[int]],
+    def __new__(
+        cls,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -328,10 +328,10 @@ class IntField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> IntField[Optional[int], Optional[int]]: ...
     @overload
-    def __init__(
-        self: IntField[Optional[int], int],
+    def __new__(
+        cls,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -345,10 +345,10 @@ class IntField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> IntField[Optional[int], int]: ...
     @overload
-    def __init__(
-        self: IntField[int, int],
+    def __new__(
+        cls,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -362,10 +362,10 @@ class IntField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> IntField[int, int]: ...
     @overload
-    def __init__(
-        self: IntField[Optional[int], int],
+    def __new__(
+        cls,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -379,10 +379,10 @@ class IntField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> IntField[Optional[int], int]: ...
     @overload
-    def __init__(
-        self: IntField[int, int],
+    def __new__(
+        cls,
         min_value: int = ...,
         max_value: int = ...,
         db_field: str = ...,
@@ -396,14 +396,14 @@ class IntField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> IntField[int, int]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class FloatField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: FloatField[Optional[float], Optional[float]],
+    def __new__(
+        cls,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -417,10 +417,10 @@ class FloatField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> FloatField[Optional[float], Optional[float]]: ...
     @overload
-    def __init__(
-        self: FloatField[Optional[float], float],
+    def __new__(
+        cls,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -434,10 +434,10 @@ class FloatField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> FloatField[Optional[float], float]: ...
     @overload
-    def __init__(
-        self: FloatField[float, float],
+    def __new__(
+        cls,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -451,10 +451,10 @@ class FloatField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> FloatField[float, float]: ...
     @overload
-    def __init__(
-        self: FloatField[Optional[float], float],
+    def __new__(
+        cls,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -468,10 +468,10 @@ class FloatField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> FloatField[Optional[float], float]: ...
     @overload
-    def __init__(
-        self: FloatField[float, float],
+    def __new__(
+        cls,
         min_value: float = ...,
         max_value: float = ...,
         db_field: str = ...,
@@ -485,14 +485,14 @@ class FloatField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> FloatField[float, float]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class DecimalField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: DecimalField[Optional[Decimal], Optional[Decimal]],
+    def __new__(
+        cls,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -509,10 +509,10 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DecimalField[Optional[Decimal], Optional[Decimal]]: ...
     @overload
-    def __init__(
-        self: DecimalField[Optional[Decimal], Decimal],
+    def __new__(
+        cls,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -529,10 +529,10 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DecimalField[Optional[Decimal], Decimal]: ...
     @overload
-    def __init__(
-        self: DecimalField[Decimal, Decimal],
+    def __new__(
+        cls,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -549,10 +549,10 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DecimalField[Decimal, Decimal]: ...
     @overload
-    def __init__(
-        self: DecimalField[Optional[Decimal], Decimal],
+    def __new__(
+        cls,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -569,10 +569,10 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DecimalField[Optional[Decimal], Decimal]: ...
     @overload
-    def __init__(
-        self: DecimalField[Decimal, Decimal],
+    def __new__(
+        cls,
         min_value: Decimal = ...,
         max_value: Decimal = ...,
         force_string: bool = ...,
@@ -589,14 +589,14 @@ class DecimalField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DecimalField[Decimal, Decimal]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class BooleanField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: BooleanField[Optional[bool], Optional[bool]],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -608,10 +608,10 @@ class BooleanField(Generic[_ST, _GT], BaseField):
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> BooleanField[Optional[bool], Optional[bool]]: ...
     @overload
-    def __init__(
-        self: BooleanField[Optional[bool], bool],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -623,10 +623,10 @@ class BooleanField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> BooleanField[Optional[bool], bool]: ...
     @overload
-    def __init__(
-        self: BooleanField[bool, bool],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -638,10 +638,10 @@ class BooleanField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> BooleanField[bool, bool]: ...
     @overload
-    def __init__(
-        self: BooleanField[Optional[bool], bool],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -653,10 +653,10 @@ class BooleanField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> BooleanField[Optional[bool], bool]: ...
     @overload
-    def __init__(
-        self: BooleanField[bool, bool],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
@@ -668,14 +668,14 @@ class BooleanField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> BooleanField[bool, bool]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class DateTimeField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: DateTimeField[Optional[datetime], Optional[datetime]],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -687,10 +687,10 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DateTimeField[Optional[datetime], Optional[datetime]]: ...
     @overload
-    def __init__(
-        self: DateTimeField[Optional[datetime], datetime],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
@@ -702,10 +702,10 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DateTimeField[Optional[datetime], datetime]: ...
     @overload
-    def __init__(
-        self: DateTimeField[datetime, datetime],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -717,10 +717,10 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DateTimeField[datetime, datetime]: ...
     @overload
-    def __init__(
-        self: DateTimeField[Optional[datetime], datetime],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[True] = ...,
@@ -732,10 +732,10 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DateTimeField[Optional[datetime], datetime]: ...
     @overload
-    def __init__(
-        self: DateTimeField[datetime, datetime],
+    def __new__(
+        cls,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: bool = ...,
@@ -747,7 +747,7 @@ class DateTimeField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> DateTimeField[datetime, datetime]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
@@ -968,8 +968,8 @@ class LazyReferenceField(BaseField):
 
 class UUIDField(Generic[_ST, _GT], BaseField):
     @overload
-    def __init__(
-        self: UUIDField[Optional[UUID], Optional[UUID]],
+    def __new__(
+        cls,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -982,10 +982,10 @@ class UUIDField(Generic[_ST, _GT], BaseField):
         null: Literal[False] = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> UUIDField[Optional[UUID], Optional[UUID]]: ...
     @overload
-    def __init__(
-        self: UUIDField[Optional[UUID], UUID],
+    def __new__(
+        cls,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -998,10 +998,10 @@ class UUIDField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> UUIDField[Optional[UUID], UUID]: ...
     @overload
-    def __init__(
-        self: UUIDField[UUID, UUID],
+    def __new__(
+        cls,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -1014,10 +1014,10 @@ class UUIDField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> UUIDField[UUID, UUID]: ...
     @overload
-    def __init__(
-        self: UUIDField[Optional[UUID], UUID],
+    def __new__(
+        cls,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -1030,10 +1030,10 @@ class UUIDField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> UUIDField[Optional[UUID], UUID]: ...
     @overload
-    def __init__(
-        self: UUIDField[UUID, UUID],
+    def __new__(
+        cls,
         binary: bool,
         db_field: str = ...,
         name: Optional[str] = ...,
@@ -1046,7 +1046,7 @@ class UUIDField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> UUIDField[UUID, UUID]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 


### PR DESCRIPTION
Pylance was complaining about params not existing when we overloaded
the __init__. Still provided autocomplete for them though.

Pyright prefers overloading the __new__ while mypy isn't picky.

rel: https://github.com/microsoft/pyright/issues/1550
rel: https://github.com/microsoft/pyright/issues/1211