### PR TITLE
add(mongoengine): missing URLField 

### DIFF
--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -104,6 +104,13 @@ class Post(Document):
     font_required_default = fields.EnumField(
         Font, required=True, default=Font.Helvetica
     )
+    url = fields.URLField()
+    url_required = fields.URLField(required=True)
+    url_default = fields.URLField(default="https://example.org")
+    url_required_default = fields.URLField(required=True, default="https://example.org")
+    url_with_extra_args = fields.URLField(
+        verify_exists=False, url_regex=None, schemas=["ftp://"], regex="bar"
+    )
 
     def set_hidden(self, hidden: bool) -> None:
         self.hidden = hidden
@@ -182,6 +189,19 @@ def main() -> None:
 
     log_required_font(first_post.font_default)
     first_post.font_default = None
+
+    def log_required_url(url: str) -> None:
+        print(url)
+
+    def log_optional_url(url: str | None) -> None:
+        print(url)
+
+    log_optional_url(first_post.url)
+    first_post.url = None
+    log_required_url(first_post.url_default)
+    first_post.url_default = None
+    log_required_url(first_post.url_required)
+    log_required_url(first_post.url_required_default)
 
     p = Post()
     p.validate()

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -111,9 +111,11 @@ class ObjectIdField(Generic[_ST, _GT], BaseField):
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class StringField(Generic[_ST, _GT], BaseField):
+    # StringField()
     @overload
-    def __init__(
-        self: StringField[Optional[str], Optional[str]],
+    def __new__(
+        cls,
+        *,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -128,17 +130,19 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[Optional[str], Optional[str]]: ...
+    # StringField(default="foo")
     @overload
-    def __init__(
-        self: StringField[Optional[str], str],
+    def __new__(
+        cls,
+        *,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[str, Callable[[], str]] = ...,
+        default: Union[str, Callable[[], str]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -146,16 +150,18 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[Optional[str], str]: ...
+    # StringField(required=True)
     @overload
-    def __init__(
-        self: StringField[str, str],
+    def __new__(
+        cls,
+        *,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -164,17 +170,19 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[str, str]: ...
+    # StringField(required=True, default="foo")
     @overload
-    def __init__(
-        self: StringField[Optional[str], str],
+    def __new__(
+        cls,
+        *,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[str, Callable[[], str]] = ...,
+        required: Literal[True],
+        default: Union[str, Callable[[], str]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -182,10 +190,12 @@ class StringField(Generic[_ST, _GT], BaseField):
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[Optional[str], str]: ...
+    # StringField(primary_key=True)
     @overload
-    def __init__(
-        self: StringField[str, str],
+    def __new__(
+        cls,
+        *,
         regex: Optional[str] = ...,
         max_length: Optional[int] = ...,
         min_length: Optional[int] = ...,
@@ -195,12 +205,12 @@ class StringField(Generic[_ST, _GT], BaseField):
         default: Union[str, Callable[[], str], None] = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
+        primary_key: Literal[True],
         choices: Optional[Iterable[str]] = ...,
         null: bool = ...,
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
-    ) -> None: ...
+    ) -> StringField[str, str]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
@@ -969,9 +979,11 @@ class LazyReferenceField(BaseField):
     def __getitem__(self, arg: Any) -> LazyReference[Any]: ...
 
 class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
+    # URLField()
     @overload
     def __new__(
         cls,
+        *,
         verify_exists: bool = ...,
         url_regex: Optional[Pattern[str]] = ...,
         schemas: Optional[Container[str]] = ...,
@@ -990,9 +1002,11 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> URLField[Optional[str], Optional[str]]: ...
+    # URLField(default="foo")
     @overload
     def __new__(
         cls,
+        *,
         verify_exists: bool = ...,
         url_regex: Optional[Pattern[str]] = ...,
         schemas: Optional[Container[str]] = ...,
@@ -1002,7 +1016,7 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         db_field: str = ...,
         name: Optional[str] = ...,
         required: Literal[False] = ...,
-        default: Union[str, Callable[[], str]] = ...,
+        default: Union[str, Callable[[], str]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -1011,9 +1025,11 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> URLField[Optional[str], str]: ...
+    # URLField(required=True)
     @overload
     def __new__(
         cls,
+        *,
         verify_exists: bool = ...,
         url_regex: Optional[Pattern[str]] = ...,
         schemas: Optional[Container[str]] = ...,
@@ -1022,7 +1038,7 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
+        required: Literal[True],
         default: None = ...,
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
@@ -1032,9 +1048,11 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> URLField[str, str]: ...
+    # URLField(required=True, default="foo")
     @overload
     def __new__(
         cls,
+        *,
         verify_exists: bool = ...,
         url_regex: Optional[Pattern[str]] = ...,
         schemas: Optional[Container[str]] = ...,
@@ -1043,8 +1061,8 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         min_length: Optional[int] = ...,
         db_field: str = ...,
         name: Optional[str] = ...,
-        required: Literal[True] = ...,
-        default: Union[str, Callable[[], str]] = ...,
+        required: Literal[True],
+        default: Union[str, Callable[[], str]],
         unique: bool = ...,
         unique_with: Union[str, Iterable[str]] = ...,
         primary_key: Literal[False] = ...,
@@ -1053,27 +1071,6 @@ class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> URLField[Optional[str], str]: ...
-    @overload
-    def __new__(
-        cls,
-        verify_exists: bool = ...,
-        url_regex: Optional[Pattern[str]] = ...,
-        schemas: Optional[Container[str]] = ...,
-        regex: Optional[str] = ...,
-        max_length: Optional[int] = ...,
-        min_length: Optional[int] = ...,
-        db_field: str = ...,
-        name: Optional[str] = ...,
-        required: bool = ...,
-        default: Union[str, Callable[[], str], None] = ...,
-        unique: bool = ...,
-        unique_with: Union[str, Iterable[str]] = ...,
-        primary_key: Literal[True] = ...,
-        choices: Optional[Iterable[str]] = ...,
-        null: bool = ...,
-        verbose_name: Optional[str] = ...,
-        help_text: Optional[str] = ...,
-    ) -> URLField[str, str]: ...
     def __set__(self, instance: Any, value: _ST) -> None: ...
     def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
@@ -1185,6 +1182,7 @@ class ReferenceField(BaseField):
 _T_ENUM = TypeVar("_T_ENUM", bound=Enum)
 
 class EnumField(Generic[_ST, _GT], BaseField):
+    # EnumField(Foo)
     @overload
     def __new__(
         cls,
@@ -1202,6 +1200,7 @@ class EnumField(Generic[_ST, _GT], BaseField):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> EnumField[Optional[_T_ENUM], Optional[_T_ENUM]]: ...
+    # EnumField(Foo, default=Foo.Bar)
     @overload
     def __new__(
         cls,
@@ -1219,6 +1218,7 @@ class EnumField(Generic[_ST, _GT], BaseField):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> EnumField[Optional[_T_ENUM], _T_ENUM]: ...
+    # EnumField(Foo, required=True)
     @overload
     def __new__(
         cls,
@@ -1236,6 +1236,7 @@ class EnumField(Generic[_ST, _GT], BaseField):
         verbose_name: Optional[str] = ...,
         help_text: Optional[str] = ...,
     ) -> EnumField[_T_ENUM, _T_ENUM]: ...
+    # EnumField(Foo, required=True, default=Foo.Bar)
     @overload
     def __new__(
         cls,

--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -6,12 +6,14 @@ from enum import Enum
 from typing import (
     Any,
     Callable,
+    Container,
     Dict,
     Generic,
     Iterable,
     Iterator,
     List,
     Optional,
+    Pattern,
     Type,
     TypeVar,
     Union,
@@ -965,6 +967,115 @@ class LazyReferenceField(BaseField):
         help_text: Optional[str] = ...,
     ) -> None: ...
     def __getitem__(self, arg: Any) -> LazyReference[Any]: ...
+
+class URLField(Generic[_ST, _GT], StringField[_ST, _GT]):
+    @overload
+    def __new__(
+        cls,
+        verify_exists: bool = ...,
+        url_regex: Optional[Pattern[str]] = ...,
+        schemas: Optional[Container[str]] = ...,
+        regex: Optional[str] = ...,
+        max_length: Optional[int] = ...,
+        min_length: Optional[int] = ...,
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[False] = ...,
+        default: None = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[str]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> URLField[Optional[str], Optional[str]]: ...
+    @overload
+    def __new__(
+        cls,
+        verify_exists: bool = ...,
+        url_regex: Optional[Pattern[str]] = ...,
+        schemas: Optional[Container[str]] = ...,
+        regex: Optional[str] = ...,
+        max_length: Optional[int] = ...,
+        min_length: Optional[int] = ...,
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[False] = ...,
+        default: Union[str, Callable[[], str]] = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[str]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> URLField[Optional[str], str]: ...
+    @overload
+    def __new__(
+        cls,
+        verify_exists: bool = ...,
+        url_regex: Optional[Pattern[str]] = ...,
+        schemas: Optional[Container[str]] = ...,
+        regex: Optional[str] = ...,
+        max_length: Optional[int] = ...,
+        min_length: Optional[int] = ...,
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[True] = ...,
+        default: None = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[str]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> URLField[str, str]: ...
+    @overload
+    def __new__(
+        cls,
+        verify_exists: bool = ...,
+        url_regex: Optional[Pattern[str]] = ...,
+        schemas: Optional[Container[str]] = ...,
+        regex: Optional[str] = ...,
+        max_length: Optional[int] = ...,
+        min_length: Optional[int] = ...,
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: Literal[True] = ...,
+        default: Union[str, Callable[[], str]] = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[False] = ...,
+        choices: Optional[Iterable[str]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> URLField[Optional[str], str]: ...
+    @overload
+    def __new__(
+        cls,
+        verify_exists: bool = ...,
+        url_regex: Optional[Pattern[str]] = ...,
+        schemas: Optional[Container[str]] = ...,
+        regex: Optional[str] = ...,
+        max_length: Optional[int] = ...,
+        min_length: Optional[int] = ...,
+        db_field: str = ...,
+        name: Optional[str] = ...,
+        required: bool = ...,
+        default: Union[str, Callable[[], str], None] = ...,
+        unique: bool = ...,
+        unique_with: Union[str, Iterable[str]] = ...,
+        primary_key: Literal[True] = ...,
+        choices: Optional[Iterable[str]] = ...,
+        null: bool = ...,
+        verbose_name: Optional[str] = ...,
+        help_text: Optional[str] = ...,
+    ) -> URLField[str, str]: ...
+    def __set__(self, instance: Any, value: _ST) -> None: ...
+    def __get__(self, instance: Any, owner: Any) -> _GT: ...
 
 class UUIDField(Generic[_ST, _GT], BaseField):
     @overload


### PR DESCRIPTION
When these types were originally created, we only added the minimal fields
necessary to support our existing codebase using mongoengine, we skipped
a few fields.

rel: https://github.com/sbdchd/mongo-types/issues/38