### PR TITLE
Let Reference Field support a Document arg

### DIFF
--- a/typings/mongoengine/fields.pyi
+++ b/typings/mongoengine/fields.pyi
@@ -1287,7 +1287,7 @@ class MapField(DictField[_T]):
 class ReferenceField(BaseField):
     def __init__(
         self,
-        model: str,
+        model: Union[str, Type[Document]],
         required: bool = ...,
         name: Optional[str] = ...,
         help_text: Optional[str] = ...,


### PR DESCRIPTION
mongoengine.fields.ReferenceField.__init__ can take a string or some type of document.
Updates typing to match using the way LazyReferenceField handles it.